### PR TITLE
Seperate commands in shell call

### DIFF
--- a/systemd-manager@hardpixel.eu/utils.js
+++ b/systemd-manager@hardpixel.eu/utils.js
@@ -55,5 +55,5 @@ function runServiceAction(method, action, type, service) {
     cmd = `pkexec --user root ${cmd}`
   }
 
-  GLib.spawn_command_line_async(`sh -c "${cmd} exit"`)
+  GLib.spawn_command_line_async(`sh -c "${cmd}; exit"`)
 }


### PR DESCRIPTION
Without this it would try to start/stop/restart the `exit.service`.

Also, are you sure the exit call is required at all?