### PR TITLE
Extend systemd polkit rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The policy file [org.freedesktop.policykit.pkexec.systemctl.policy](systemd-poli
 confirmation. Copy the file in your polkit policy folder (usually: `/usr/share/polkit-1/actions`).
 
 #### Using systemctl
-You can also choose to use `systemctl` natively and bypass a password prompt. To do this, add the policy file [10-service_status.rules](10-service_status.rules) to `/etc/polkit-1/rules.d`.
+You can also choose to use `systemctl` natively and bypass a password prompt. To do this, add the policy file [10-service_status.rules](systemd-policies/10-service_status.rules) to `/etc/polkit-1/rules.d`.
 
 Feel free to change the `wheel` group noted in the file to any other group that you see fit.
 

--- a/systemd-policies/10-service_status.rules
+++ b/systemd-policies/10-service_status.rules
@@ -1,8 +1,12 @@
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.freedesktop.systemd1.manage-units" && subject.isInGroup("wheel") ) {
-        var verb = action.lookup("verb");
-        if (verb == "start" || verb == "stop" || verb == "restart" || verb == "enable" || verb == "disable") {
-            return polkit.Result.YES;
-        }
+    var allowedUnits = new Array("unbound.service", "docker.service");
+    var allowedVerbs = new Array("start", "stop", "restart", "enable", "disable");
+    if (
+        action.id == "org.freedesktop.systemd1.manage-units" &&
+        subject.isInGroup("wheel") &&
+        allowedUnits.indexOf(action.lookup("unit") >= 0) &&
+        allowedVerbs.indexOf(action.lookup("verb") >= 0)
+    ) {
+        return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
Adds optional limits to specific systemd services to the polkit rule example.

Also fixes the link in the README.