### PR TITLE
Don't ask for password when sudo is allowed

### DIFF
--- a/systemd-manager@hardpixel.eu/utils.js
+++ b/systemd-manager@hardpixel.eu/utils.js
@@ -52,7 +52,7 @@ function runServiceAction(method, action, type, service) {
   let cmd = `systemctl ${action} ${service} --${type}`
 
   if (method == 0 && type == 'system') {
-    cmd = `pkexec --user root ${cmd}`
+    cmd = `(sudo -V && sudo -n ${cmd}) || pkexec --user root ${cmd}`
   }
 
   GLib.spawn_command_line_async(`sh -c "${cmd}; exit"`)


### PR DESCRIPTION
Uses `sudo -V` to guarantee _sudo_ is installed (just to be sure).
Execute `sudo -n` which will fail if it needs a password.
Execute `pkexec` otherwise.

Resolves #7