### PR TITLE
Center dropdown

### DIFF
--- a/systemd-manager@hardpixel.eu/extension.js
+++ b/systemd-manager@hardpixel.eu/extension.js
@@ -13,7 +13,7 @@ class SystemdManager extends PanelMenu.Button {
   }
 
   constructor(ext) {
-    super(0.2, null, false)
+    super(0.5, null, false)
 
     this._settings = ext.getSettings()
     this._settings.connect('changed', () => this.refresh(ext))


### PR DESCRIPTION
Thank you for this extension!

In recent Gnome versions the dropdown menus on the panel are center aligned to their button. With this change systemd-manager will follow this new convention.

Before:
![systemdmanager_before](https://github.com/hardpixel/systemd-manager/assets/1271737/8f08df06-8b83-472e-844a-049ca0baed9d)

After:
![systemdmanager_after](https://github.com/hardpixel/systemd-manager/assets/1271737/23fc3e59-c389-44fe-9b5a-fdfd5a9c4aae)

