### PR TITLE
Removed the gnome-shell delay after opening the dropdown

### DIFF
--- a/systemd-manager@hardpixel.eu/extension.js
+++ b/systemd-manager@hardpixel.eu/extension.js
@@ -1,4 +1,5 @@
 import GObject from 'gi://GObject'
+import GLib from 'gi://GLib'
 import St from 'gi://St'
 import * as Ext from 'resource:///org/gnome/shell/extensions/extension.js'
 import * as Main from 'resource:///org/gnome/shell/ui/main.js'
@@ -28,7 +29,9 @@ class SystemdManager extends PanelMenu.Button {
 
     this.menu.connect('open-state-changed', () => {
       if (this.menu.isOpen) {
-        this.refresh(ext)
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, _ => {
+            this.refresh(ext)
+        })
       }
     })
   }


### PR DESCRIPTION
Hello, I noticed there is a small delay (maybe 40ms?) in gnome-shell after opening the dropdown, probably caused by the fact that a function is called synchronously and it is not so fast to execute.

With this change, the function is called asynchronously, and it seems to remove the lag! Please try it and see if it changes it for you too, and if so that can be a good addition :)